### PR TITLE
fix freecell autoplay

### DIFF
--- a/games/freecell.scm
+++ b/games/freecell.scm
@@ -78,6 +78,8 @@
 					  fields fields fields
 					  half-fields))))
 
+
+	
 ;;
 ;; Utilities
 ;;
@@ -198,7 +200,7 @@
 			(eq? (get-value card) ace)
 			(add-to-score! 1)
 			(add-card! homecell-id card)
-			(update-auto (get-suit card) (get-value card)))
+			)
 		#t)
 		; Put a +1 card into the homecell, whose suit is same.
 		((and
@@ -206,7 +208,7 @@
 			(homecell-join? (car (get-cards homecell-id)) card)
 			(add-to-score! 1)
 			(add-card! homecell-id card)
-			(update-auto (get-suit card) (get-value card)))
+			)
 		#t)
 		(#t #f)
 	)
@@ -253,63 +255,54 @@
 ;; Auto move stuffs
 ;;
 
-(def-save-var highest-club 0)
-(def-save-var highest-diamond 0)
-(def-save-var highest-heart 0)
-(def-save-var highest-spade 0)
+(define autoplay #t)
 
-(define (update-auto suit value)
-	(cond
-		((eq? suit club) (set! highest-club value))
-		((eq? suit diamond) (set! highest-diamond value))
-		((eq? suit heart) (set! highest-heart value))
-		((eq? suit spade) (set! highest-spade value))
-	)
-)
-
-(define (max-auto-red)
-	(min
-		(+ 2 (min highest-club highest-spade))
-		(+ 3 (min highest-diamond highest-heart))
-	)
-)
-
-(define (max-auto-black)
-	(min
-		(+ 2 (min highest-diamond highest-heart))
-		(+ 3 (min highest-club highest-spade))
-	)
-)
-
-(define (move-low-cards slot)
-  (or
-   (and
-    (not (homecell? slot))
-    (not (empty-slot? slot))
-    (let ((card (get-top-card slot)))
-      (if (= (get-color card) red)
-	  (and
-	   (<= (get-value card) (max-auto-red))
-	   (move-card-to-homecell card (homecell-by-suit (get-suit card)))
-	   (remove-card slot)
-	   (delayed-call ((lambda (x) (lambda () (move-low-cards x))) 0))
-	   )
-	  (and
-	   (<= (get-value card) (max-auto-black))
-	   (move-card-to-homecell card (homecell-by-suit (get-suit card)))
-	   (remove-card slot)
-	   (delayed-call ((lambda (x) (lambda () (move-low-cards x))) 0))
-					;	(move-low-cards 0)
-	   )
-	  )
-      )
-    )
-   (if (< slot field-8)
-       (move-low-cards (+ 1 slot))
-       #t
-       )
-   )
+(define (get-options) 
+  (list
+    'begin-exclusive 
+	  (list (_"Autoplay On") autoplay)
+	  (list (_"Autoplay Off") (not autoplay))
+	'end-exclusive
   )
+)
+		
+(define (apply-options options)
+  (set! autoplay (cadr (list-ref options 1)))
+)
+          
+(define (move-low-cards slot)	;;; this is routine which auto moves cards including the final
+								;;; batch when near the end of a winning game. Examines the freecells
+								;;; and all the fields; skips over the home cells of course.
+								;;; Scans slots 0 (freecell-1) to 15 (field-8) recursively looking for
+								;;; any cards that can be moved to the home cells.
+	(if autoplay	;; Only do the auto play if the option is checked.
+		(begin
+	
+			(or				;;; try to move a card from the current slot; if not, then
+								;;; move on to the next slot; If a card is moved, then make a
+								;;; recursive call, starting over at slot 0 (freecell-1), looking
+								;;; for more cards to move.
+								
+				(and		;;; try to move a card. If successfull, remove it from the slot
+								;;; and start scanning again.
+					(not (homecell? slot))
+					(not (empty-slot? slot))
+					(let ((card (get-top-card slot)))
+						(and
+							(move-card-to-homecell card (homecell-by-suit (get-suit card)))  				;; move if one higher than the card in the home cell
+							(remove-card slot)  ;; card was moved ok, now remove it from old slot
+							(delayed-call ((lambda (x) (lambda () (move-low-cards x))) freecell-1))	;; card was moved. start fresh search
+						)
+					)
+				)
+				(if (< slot field-8)					;; no card moved - try next slot if more to go
+					(move-low-cards (+ 1 slot))	;; try next slot;
+					#t													;; all slots have been checked; exit/return.
+				)
+			)
+		)
+	)
+)
 
 ;;
 ;; Callbacks & Initialize the game
@@ -356,11 +349,6 @@
 
   (add-blank-slot)
   (deal-initial-setup)
-  (update-auto club 0)
-  (update-auto diamond 0)
-  (update-auto heart 0)
-  (update-auto spade 0)
-
   (set! board-hash (make-hash-table hash-size))
   
 
@@ -420,12 +408,6 @@
        (= 13 (length (get-cards homecell-2)))
        (= 13 (length (get-cards homecell-3)))
        (= 13 (length (get-cards homecell-4)))))
-
-(define (get-options) 
-  #f)
-
-(define (apply-options options) 
-  #f)
 
 (define (timeout) 
   ; (FIXME)


### PR DESCRIPTION
Freecell's autoplay did not move all possible cards to home cells. Fixed. Also added option to turn autoplay on and off. Removed unused code.